### PR TITLE
Ensure invariant culture and consistent braces

### DIFF
--- a/StyleIssues/CA1304/MyClass.cs
+++ b/StyleIssues/CA1304/MyClass.cs
@@ -6,7 +6,7 @@ namespace StyleIssues.CA1304
     {
         public static string MyMethod(string str)
         {
-            return "K-" + str.ToUpper(CultureInfo.CurrentCulture);
+            return "K-" + str.ToUpper(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/StyleIssues/CA1305/MyClass.cs
+++ b/StyleIssues/CA1305/MyClass.cs
@@ -1,10 +1,12 @@
+using System.Globalization;
+
 namespace StyleIssues.CA1305
 {
     public static class MyClass
     {
         public static string MyMethod(int i)
         {
-            return $"X{i}";
+            return "X" + i.ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/StyleIssues/CA1507/MyClass.cs
+++ b/StyleIssues/CA1507/MyClass.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace StyleIssues.CA1507
 {
     public static class MyClass

--- a/StyleIssues/SA1028/Math.cs
+++ b/StyleIssues/SA1028/Math.cs
@@ -4,8 +4,7 @@ namespace StyleIssues.SA1028
     {
         public static int Sum(int x, int y)
         {
-            return
-                x + y;
+            return x + y;
         }
     }
 }

--- a/StyleIssues/SA1500/Math.cs
+++ b/StyleIssues/SA1500/Math.cs
@@ -2,6 +2,9 @@ namespace StyleIssues.SA1500
 {
     public static class Math
     {
-        public static int Sum(int x, int y) => x + y;
+        public static int Sum(int x, int y)
+        {
+            return x + y;
+        }
     }
 }

--- a/StyleIssues/SA1508/Math.cs
+++ b/StyleIssues/SA1508/Math.cs
@@ -2,6 +2,9 @@ namespace StyleIssues.SA1508
 {
     public static class Math
     {
-        public static int Sum(int x, int y) => x + y;
+        public static int Sum(int x, int y)
+        {
+            return x + y;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- use CultureInfo.InvariantCulture for culture-sensitive conversions
- add the missing System namespace for the CA1507 guard
- expand math helpers to block-bodied methods to satisfy StyleCop formatting rules

## Testing
- not run (dotnet CLI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3ba8d3fb0832d8fa6df20ebd4f9c5